### PR TITLE
fix for numeric values

### DIFF
--- a/src/jquery.table2excel.js
+++ b/src/jquery.table2excel.js
@@ -52,7 +52,15 @@
                         if(flag.length >= 1) {
                             tempRows += "<td> </td>" // exclude it!!
                         } else {
-                            tempRows += "<td>" + $(q).html() + "</td>"
+                            var tx = $.trim($(q).html());
+                            if ($.isNumeric(tx) & tx!="")
+                            {
+                                tempRows += "<td>=\"" + tx + "\"</td>";
+
+                            } else {
+                                tempRows += "<td>" + tx + "</td>";
+
+                            }
                         }
                     })
                      


### PR DESCRIPTION
this fix will allow FULLY numeric values to be passed with the = function and quotes so trailing zeros will not be deleted. this also trims the html otherwise you get a space on either side.
